### PR TITLE
Updating Gulp to v4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,43 +1,52 @@
-var gulp   = require('gulp');
-var concat = require('gulp-concat');
-var rename = require('gulp-rename');
-var uglify = require('gulp-uglify');
-var cssmin = require('gulp-cssmin');
+const {src, dest, watch, parallel} = require('gulp');
+const concat = require('gulp-concat');
+const rename = require('gulp-rename');
+const uglify = require('gulp-uglify');
+const cssmin = require('gulp-clean-css');
 
-gulp.task('js', function() {
 
-  return gulp.src([
-      'assets/src/js/prism.js',
-      'assets/src/js/index.js'
-    ]) 
-    .pipe(concat('index.js')) 
-    .pipe(gulp.dest('assets/dist'))
-    .pipe(rename('index.min.js'))
-    .pipe(uglify()) 
-    .pipe(gulp.dest('assets/dist'));
-
-});
-
-gulp.task('css', function() {
-
-  return gulp.src([
-      'assets/src/css/prism.css',
-      'assets/src/css/index.css',
-    ])  
-    .pipe(concat('index.css')) 
-    .pipe(gulp.dest('assets/dist'))
+function css() {
+  return src([
+    'assets/src/css/prism.css',
+    'assets/src/css/index.css',
+  ])
+    .pipe(concat('index.css'))
+    .pipe(dest('assets/dist'))
+    .pipe(cssmin())
     .pipe(rename('index.min.css'))
-    .pipe(cssmin()) 
-    .pipe(gulp.dest('assets/dist'));    
+    .pipe(dest('assets/dist'));
+}
 
-});
 
-gulp.task('watch', function() {
-  gulp.watch('assets/src/**/*.css', ['css']);
-  gulp.watch('assets/src/**/*.js', ['js']);
-});
+function js() {
+  return src([
+    'assets/src/js/prism.js',
+    'assets/src/js/index.js',
+  ])
+    .pipe(concat('index.js'))
+    .pipe(dest('assets/dist'))
+    .pipe(uglify())
+    .pipe(rename('index.min.js'))
+    .pipe(dest('assets/dist'));
+}
 
-gulp.task('default', [
-  'css', 
-  'js'
-]);
+
+function watchScripts() {
+  watch('assets/src/**/*.js', js);
+}
+
+function watchStyles() {
+  watch('assets/src/**/*.css', css);
+}
+
+
+module.exports = {
+  default: parallel(
+    css,
+    js
+  ),
+  watch: parallel(
+    watchStyles,
+    watchScripts
+  ),
+};

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "Kirby Patterns Plugin",
   "license": "MIT",
   "type": "kirby-plugin",
+  "scripts": {
+    "start": "gulp watch",
+    "build": "gulp"
+  },
   "devDependencies": {
-    "gulp": "^3.9.0",
-    "gulp-concat": "^2.6.0",
-    "gulp-cssmin": "^0.1.7",
-    "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4",
-    "gulp-uglify": "^1.4.2"
+    "gulp": "^4.0.0",
+    "gulp-concat": "^2.6.1",
+    "gulp-cssmin": "^0.2.0",
+    "gulp-rename": "^1.4.0",
+    "gulp-sass": "^4.0.2",
+    "gulp-uglify": "^3.0.2"
   }
 }


### PR DESCRIPTION
Thank you very much for upholding this great plugin!

Here are some changes I want to chip in:
- Updated Gulp to v4.0.0 & migrated tasks
- Updated dependencies to latest versions
- Replaced gulp-cssmin with gulp-clean-css (as explained [here](https://github.com/gulpjs/plugins/blob/master/src/blackList.json#L74))